### PR TITLE
Updates for more modern Alien::Base

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -30,6 +30,7 @@ my $builder = Alien::Base::ModuleBuild->new(
         },
     },
     alien_name       => 'chipmunk',
+    alien_isolate_dynamic => 1,
     alien_repository => {
         protocol => 'http',
         host     => 'chipmunk-physics.net',

--- a/Build.PL
+++ b/Build.PL
@@ -2,9 +2,10 @@ use strict;
 use warnings;
 use lib 'inc';
 use My::ModuleBuild;
+use Config;
 
 my $cflags = '';
-my $libs   = '-lchipmunk';
+my $libs   = join(' ', '-lchipmunk', grep(/^-lm$/, split /\s+/, $Config{libs}));
 
 if($ENV{ALIEN_CHIPMUNK_PREFIX}) {
   $cflags = "-I$ENV{ALIEN_CHIPMUNK_PREFIX}/include/chipmunk";

--- a/Build.PL
+++ b/Build.PL
@@ -1,8 +1,23 @@
 use strict;
 use warnings;
-use Alien::Base::ModuleBuild;
+use lib 'inc';
+use My::ModuleBuild;
 
-my $builder = Alien::Base::ModuleBuild->new(
+my $cflags = '';
+my $libs   = '-lchipmunk';
+
+if($ENV{ALIEN_CHIPMUNK_PREFIX}) {
+  $cflags = "-I$ENV{ALIEN_CHIPMUNK_PREFIX}/include/chipmunk";
+  $libs   = "-L$ENV{ALIEN_CHIPMUNK_PREFIX}/lib $libs";
+} else {
+  foreach my $dir (map { "$_/chipmunk" } qw( /usr/include /usr/local/include )) {
+    if(-r "$dir/chipmunk.h") {
+      $cflags = "-I$dir";
+    }
+  }
+}
+
+my $builder = My::ModuleBuild->new(
     module_name        => 'Alien::Chipmunk',
     dist_abstract      => 'Build and install the Chipmunk Physics library',
     dist_author        => 'Jeffrey T. Palmer <jtpalmer@cpan.org>',
@@ -19,7 +34,7 @@ my $builder = Alien::Base::ModuleBuild->new(
     },
     requires => {
         'perl'        => '5.8.1',
-        'Alien::Base' => 0.006,
+        'Alien::Base' => '0.020',
     },
     add_to_cleanup => [ 't/src/test.o', 't/src/test' ],
     meta_merge     => {
@@ -31,6 +46,8 @@ my $builder = Alien::Base::ModuleBuild->new(
     },
     alien_name       => 'chipmunk',
     alien_isolate_dynamic => 1,
+    alien_provides_cflags => $cflags,
+    alien_provides_libs => $libs,
     alien_repository => {
         protocol => 'http',
         host     => 'chipmunk-physics.net',
@@ -39,7 +56,10 @@ my $builder = Alien::Base::ModuleBuild->new(
     },
     alien_build_commands => [
         'cmake -DBUILD_DEMOS=OFF -DCMAKE_INSTALL_PREFIX=%s',
-        'make', 'make install',
+        'make',
+    ],
+    alien_install_commands => [
+        'make install'
     ],
 );
 

--- a/Build.PL
+++ b/Build.PL
@@ -13,11 +13,13 @@ my $builder = Alien::Base::ModuleBuild->new(
     },
     build_requires => {
         'Test::More'   => 0,
+    },
+    alien_bin_requires => {
         'Alien::CMake' => '0.03',
     },
     requires => {
         'perl'        => '5.8.1',
-        'Alien::Base' => 0,
+        'Alien::Base' => 0.006,
     },
     add_to_cleanup => [ 't/src/test.o', 't/src/test' ],
     meta_merge     => {

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,7 @@
 Build.PL
 Changes
+inc/My/ModuleBuild.pm
+inc/My/test.c
 lib/Alien/Chipmunk.pm
 LICENSE
 MANIFEST

--- a/inc/My/ModuleBuild.pm
+++ b/inc/My/ModuleBuild.pm
@@ -1,0 +1,48 @@
+package My::ModuleBuild;
+
+use strict;
+use warnings;
+use base 'Alien::Base::ModuleBuild';
+use File::Spec;
+use Config;
+
+sub alien_check_installed_version {
+  my($self) = @_;
+  
+  my $b = $self->cbuilder;
+  
+  my $obj = eval {
+    $b->compile(
+      source               => File::Spec->catfile(qw( inc My test.c )),
+      extra_compiler_flags => $self->alien_provides_cflags,
+    );
+  };
+  
+  return unless defined $obj;
+
+  $self->add_to_cleanup($obj);
+  
+  my($exe, @rest) = eval {
+    $b->link_executable(
+      objects            => [$obj],
+      extra_linker_flags => $self->alien_provides_libs . " $Config{libs}",
+    );
+  };
+  
+  unlink $obj;
+  
+  return unless defined $exe;
+  
+  $self->add_to_cleanup($exe, @rest);
+  $DB::single = 1;
+  if(`$exe` =~ /version=([0-9\.]+)/) {
+    my $version = $1;
+    unlink $exe, @rest;
+    # requires version 6.x (or better?)
+    return unless $version =~ /^([0-9]+)/ && $1 >= 6;
+    return $version;
+  }  
+  return;  
+}
+
+1;

--- a/inc/My/ModuleBuild.pm
+++ b/inc/My/ModuleBuild.pm
@@ -34,7 +34,7 @@ sub alien_check_installed_version {
   return unless defined $exe;
   
   $self->add_to_cleanup($exe, @rest);
-  $DB::single = 1;
+
   if(`$exe` =~ /version=([0-9\.]+)/) {
     my $version = $1;
     unlink $exe, @rest;

--- a/inc/My/ModuleBuild.pm
+++ b/inc/My/ModuleBuild.pm
@@ -25,7 +25,7 @@ sub alien_check_installed_version {
   my($exe, @rest) = eval {
     $b->link_executable(
       objects            => [$obj],
-      extra_linker_flags => $self->alien_provides_libs . " $Config{libs}",
+      extra_linker_flags => $self->alien_provides_libs,
     );
   };
   

--- a/inc/My/test.c
+++ b/inc/My/test.c
@@ -1,0 +1,9 @@
+#include <chipmunk.h>
+#include <stdio.h>
+
+int
+main(int argc, char *argv[])
+{
+  printf("version=%s\n", cpVersionString);
+  return 0;
+}

--- a/t/01-config.t
+++ b/t/01-config.t
@@ -11,8 +11,11 @@ my $alien = Alien::Chipmunk->new;
 diag( 'CFLAGS=' . $alien->cflags );
 diag( 'LIBS=' . $alien->libs );
 
-like( $alien->cflags, qr/-I/ );
-like( $alien->libs,   qr/-L/ );
+SKIP: {
+  skip "system libs may not need -I or -L", 2 if $alien->install_type('system');  
+  like( $alien->cflags, qr/-I/ );
+  like( $alien->libs,   qr/-L/ );
+}
 
 done_testing();
 

--- a/t/02-compile.t
+++ b/t/02-compile.t
@@ -21,7 +21,7 @@ SKIP: {
 
     my $exe = $cb->link_executable(
         objects            => [$obj],
-        extra_linker_flags => $alien->libs . ' -lm',
+        extra_linker_flags => $alien->libs . " $Config{libs}",
     );
     is( defined $exe, 1, "Linking test.c" );
 

--- a/t/02-compile.t
+++ b/t/02-compile.t
@@ -12,10 +12,6 @@ SKIP: {
 
     my $alien = Alien::Chipmunk->new();
 
-    my @L = $alien->libs =~ /-L(\S+)/g;
-    $ENV{LD_RUN_PATH} = join( $Config::Config{path_sep}, @L );
-    diag( 'LD_RUN_PATH=' . $ENV{LD_RUN_PATH} );
-
     my $cb = ExtUtils::CBuilder->new( quiet => 0 );
     my $obj = $cb->compile(
         source               => 't/src/test.c',

--- a/t/02-compile.t
+++ b/t/02-compile.t
@@ -21,7 +21,7 @@ SKIP: {
 
     my $exe = $cb->link_executable(
         objects            => [$obj],
-        extra_linker_flags => $alien->libs . " $Config{libs}",
+        extra_linker_flags => $alien->libs,
     );
     is( defined $exe, 1, "Linking test.c" );
 

--- a/t/02-compile.t
+++ b/t/02-compile.t
@@ -4,30 +4,26 @@ use Test::More;
 use Alien::Chipmunk;
 use Config;
 
-SKIP: {
-    skip "This test is broken on cygwin" if $^O eq 'cygwin';
+eval "use ExtUtils::CBuilder 0.2703";
+plan skip_all => "ExtUtils::CBuilder 0.2703 required for this test" if $@;
 
-    eval "use ExtUtils::CBuilder 0.2703";
-    skip "ExtUtils::CBuilder 0.2703 required for this test" if $@;
+my $alien = Alien::Chipmunk->new();
 
-    my $alien = Alien::Chipmunk->new();
+my $cb = ExtUtils::CBuilder->new( quiet => 0 );
+my $obj = $cb->compile(
+    source               => 't/src/test.c',
+    extra_compiler_flags => $alien->cflags,
+);
+is( defined $obj, 1, "Compiling test.c" );
 
-    my $cb = ExtUtils::CBuilder->new( quiet => 0 );
-    my $obj = $cb->compile(
-        source               => 't/src/test.c',
-        extra_compiler_flags => $alien->cflags,
-    );
-    is( defined $obj, 1, "Compiling test.c" );
+my $exe = $cb->link_executable(
+    objects            => [$obj],
+    extra_linker_flags => $alien->libs,
+);
+is( defined $exe, 1, "Linking test.c" );
 
-    my $exe = $cb->link_executable(
-        objects            => [$obj],
-        extra_linker_flags => $alien->libs,
-    );
-    is( defined $exe, 1, "Linking test.c" );
-
-    my $rv = system($exe);
-    is( $rv, 0, "Executing test" );
-}
+my $rv = system($exe);
+is( $rv, 0, "Executing test" );
 
 done_testing();
 


### PR DESCRIPTION
This PR includes a number improvements that take advantage of more recent versions of `Alien::Base`.  In my experience these improvements have improves the reliability of other `Alien::Base` based Alien modules.

 - use the system libchipmunk if it is available (also the "system" chipmunk can be specified with the `ALIEN_CHIPMUNK_PREFIX` environment variable, since it doesn't use pkg-config or foo-config type discovery)
 - I required version 6.x or better ... as it seemed that was necessary (my debian system only had 5.x, but the current stable has 6.x) for the compile test.  An alternative might be to change the compile test.
 - only require `Alien::CMake` if a build from source is required
 - use static libchipmunk for XS (Do not have to muck with `LD_RUN_PATH`, or equivalent for each platform, and `Alien::Chipmunk` is no longer a run-time dep).
 - use -lm only if it appears necessary
 - tested on cygwin, and re-enabled the compile test on that platform.  I believe the `-lm` and the `LD_RUN_PATH` was breaking it on that platform.