### PR TITLE
use AB::MB for configure_requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -29,7 +29,7 @@ my $builder = My::ModuleBuild->new(
     license            => 'mit',
     configure_requires => {
         'Module::Build' => 0,
-        'Alien::Base'   => 0,
+        'Alien::Base::ModuleBuild'   => 0,
     },
     build_requires     => { 'Test::More'   => 0, },
     alien_bin_requires => { 'Alien::CMake' => '0.03', },


### PR DESCRIPTION
This will ensure that `Alien::Base::ModuleBuild` is (correctly) specified as configure_requires instead of `Alien::Base`.  For the rationale for this change, please see https://github.com/Perl5-Alien/Alien-Base/issues/157
